### PR TITLE
Add more options for request expiry plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 - `sanitizePath` now available only on the `pre` export
 - `mapParams: false` is now the default setting for both the queryParser and
   bodyParser plugins
+- request expiration plugin now has two options, absolute time and timeout, the
+  signature of the options has changed.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://david-dm.org/restify/plugins.svg)](https://david-dm.org/restify/plugins)
 [![devDependency Status](https://david-dm.org/restify/plugins/dev-status.svg)](https://david-dm.org/restify/plugins#info=devDependencies)
 [![bitHound Score](https://www.bithound.io/github/restify/plugins/badges/score.svg)](https://www.bithound.io/github/restify/plugins/master)
-[![NSP Status](https://img.shields.io/badge/NSP%20status-vulnerabilities%20found-red.svg)](https://travis-ci.org/restify/plugins)
+[![NSP Status](https://img.shields.io/badge/NSP%20status-no%20vulnerabilities-green.svg)](https://travis-ci.org/restify/plugins)
 
 > A collection of core restify plugins
 

--- a/lib/plugins/requestExpiry.js
+++ b/lib/plugins/requestExpiry.js
@@ -4,26 +4,56 @@ var assert = require('assert-plus');
 var GatewayTimeoutError = require('restify-errors').GatewayTimeoutError;
 
 /**
- * A request expiry will use the headers to tell if the
- * incoming request has expired or not.  The header is
- * expected to be in absolute time since the epoch.
+ * A request expiry will use headers to tell if the
+ * incoming request has expired or not. There are two options for this plugin:
+ *  1. Absolute Time
+ *     * Time in Milliseconds since the Epoch when this request should be
+ *       considered expired
+ *  2. Timeout
+ *     * The request start time is supplied
+ *     * A timeout, in milliseconds, is given
+ *     * The timeout is added to the request start time to arrive at the
+ *       absolute time in which the request is considered expired
  * @public
  * @function requestExpiry
  * @param    {Object} options        an options object
- * @param    {String} options.header The header key to be used for
+ * @param    {String} options.absoluteHeader The header key to be used for
  *                                   the expiry time of each request.
+ * @param    {String} options.startHeader The header key for the start time
+ *                                   of the request.
+ * @param    {String} options.timeoutHeader The header key for the time in
+ *                                   milliseconds that should ellapse before
+ *                                   the request is considered expired.
  * @returns  {Function}
  */
 function requestExpiry(options) {
     assert.object(options, 'options');
-    assert.string(options.header, 'options.header');
-    var headerKey = options.header;
+    assert.optionalString(options.absoluteHeader, 'options.absoluteHeader');
+    assert.optionalString(options.startHeader, 'options.startHeader');
+    assert.optionalString(options.timeoutHeader, 'options.timeoutHeader');
+
+    var useAbsolute = (options.absoluteHeader !== undefined);
+    var absoluteHeaderKey = options.absoluteHeader;
+    var startHeaderKey = options.startHeader;
+    var timeoutHeaderKey = options.timeoutHeader;
 
     return function (req, res, next) {
-        var expiry = req.headers[headerKey];
+        var expiryTime;
 
-        if (expiry) {
-            var expiryTime = Number(expiry);
+        if (useAbsolute) {
+            expiryTime = Number(req.headers[absoluteHeaderKey]);
+        } else {
+            // Use the start time header and add the timeout header to it
+            // to arrive at the expiration time
+            var startTime = req.headers[startHeaderKey];
+            var timeout = req.headers[timeoutHeaderKey];
+
+            if (startTime && timeout) {
+                expiryTime = Number(startTime) + Number(timeout);
+            }
+        }
+
+        if (expiryTime) {
 
             // The request has expired
             if (Date.now() > expiryTime) {


### PR DESCRIPTION
Rename the option for the request expiration header to `absoluteHeader`.

Add two new options: `startHeader` and `timeoutHeader`, which are added together to determine the absolute epoch time for expiration.

Fixes #3 
