### PR TITLE
Cors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 1.1.0
+
+- NEW: unified CORS plugin for both preflight and regular requests
+  - allow customization of allowed/exposed headers
+  - use matched origin for non-credential requests
+  - various new options (see README.md)
+- BREAKING: remove all CORS access-control-* headers from the fullResponse plugin
+
 # 1.0.2
 
 - merges [commit](https://github.com/restify/node-restify/commit/fbd56f5751f82031c8b0e677f0bdd677c7b95892)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module includes the following header parser plugins:
 * `authorizationParser(options)` - Authorization header
   * `options` {Object} options object passed to http-signature module
 * `conditionalRequest()` - Conditional headers (If-\*)
-* `fullResponse()` - handles disappeared CORS headers
+* `fullResponse()` - adds universal response headers
 
 This module includes the following data parsing plugins:
 
@@ -82,7 +82,50 @@ The module includes the following response plugins:
   * `options.startHeader` {String} header name for the start time of the request
   * `options.timeoutHeader` {String}  The header name for the time in milliseconds that should ellapse before the request is considered expired.
 
+### CORS
 
+This module also includes CORS support:
+
+* `cors(options)`
+  * `options.origins` {Array} array of origins to allow
+  * `options.credentials` {Boolean} enable credentialed requests
+  * `options.allowHeaders` {Array} array of header names to allow
+  * `options.exposeHeaders` {Array} array of header names to expose
+  * `options.preflightMaxAge` {Number} time in ms to set for access-control-max-age header. Defaults to 3600 (5min).
+  * `options.preflightStrategy` {restify server | Function | Boolean} strategy for handling preflight requests
+
+The CORS plugin now returns two values, one for handling preflight and one
+for handling standard requests. The preflight strategy can accept an
+instance of your restify server to automatically handle preflight requests.
+Alternatively, you can provide a function that returns the list of supported
+methods for a given request. If a value is not provided, then the preflight
+handler will not be created for you. In that scenario, server.opts must be
+manually defined on every CORS resource. Here's an example:
+
+```js
+var cors = plugins.cors({
+    origins: [ 'http://somesite.local', '*'],
+    allowHeaders: [ 'x-foobar' ],
+    preflightStrategy: server
+});
+
+server.pre(cors.preflight);
+server.use(cors.headers);
+```
+
+If you choose to use a custom function to do resolution:
+
+```js
+function preflightStrategy(req, res, callback) {
+    var url = req.path();
+
+    // given an incoming request, let's say the requested url is
+    // /foobar, you must return an array of method names supported by
+    // that url.
+
+    return callback(null, ['GET', 'POST']);
+}
+```
 
 ## Contributing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
     authorizationParser: require('./plugins/authorization'),
     bodyParser: require('./plugins/bodyParser'),
     conditionalRequest: require('./plugins/conditionalRequest'),
+    cors: require('./plugins/cors'),
     dateParser: require('./plugins/date'),
     jsonp: require('./plugins/jsonp'),
     urlEncodedBodyParser: require('./plugins/formBodyParser'),

--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -2,10 +2,12 @@
 
 'use strict';
 
+///--- external modules
 var assert = require('assert-plus');
+var errs = require('restify-errors');
 
 
-///--- Globals
+///--- local globals
 
 var ALLOW_HEADERS = [
     'accept',
@@ -27,27 +29,45 @@ var EXPOSE_HEADERS = [
     'response-time'
 ];
 
-// Normal
-var AC_ALLOW_ORIGIN = 'Access-Control-Allow-Origin';
-var AC_ALLOW_CREDS = 'Access-Control-Allow-Credentials';
-var AC_EXPOSE_HEADERS = 'Access-Control-Expose-Headers';
+var AC_REQ_METHOD = 'access-control-request-method';
+var AC_REQ_HEADERS = 'access-control-request-headers';
+var AC_ALLOW_CREDS = 'access-control-allow-credentials';
+var AC_ALLOW_ORIGIN = 'access-control-allow-origin';
+var AC_ALLOW_HEADERS = 'access-control-allow-headers';
+var AC_ALLOW_METHODS = 'access-control-allow-methods';
+var AC_EXPOSE_HEADERS = 'access-control-expose-headers';
+var AC_MAX_AGE = 'access-control-max-age';
+var AC_MAX_AGE_MS = 3600;
+var STR_VARY = 'vary';
+var STR_ORIGIN = 'origin';
 
 
 ///--- Internal Functions
 
-function matchOrigin(req, origins) {
-    var origin = req.headers.origin;
+/**
+ * find a possible match given an incoming origin header against an array of
+ * known whitelisted origins.
+ * @private
+ * @function matchOrigin
+ * @param {String} incomingOrigin the incoming origin header
+ * @param {Array} origins an array of origin strings
+ * @returns {String | Boolean}
+ */
+function matchOrigin(incomingOrigin, origins) {
 
-    function belongs(o) {
-        if (origin === o || o === '*') {
-            origin = o;
-            return (true);
-        }
+    var matched = false;
 
-        return (false);
+    if (incomingOrigin) {
+        origins.some(function belong(o) {
+            if (o === incomingOrigin || o === '*') {
+                matched = o;
+                return true;
+            }
+            return false;
+        });
     }
 
-    return ((origin && origins.some(belongs)) ? origin : false);
+    return matched;
 }
 
 
@@ -73,66 +93,225 @@ function matchOrigin(req, origins) {
  * Pre-flight requests are handled by the router internally
  *
  * @public
- * @function cors
- * @param    {Object}   options an options object
- * @returns  {Function}
+ * @function createCorsContext
+ * @param    {Object} options an options object
+ * @param    {Array} [options.origins] an array of whitelisted origins
+ * @param    {Boolean} [options.credentials] if true, uses creds
+ * @param    {Array} [options.allowHeaders] user defined headers to allow
+ * @param    {Array} [options.exposeHeaders] user defined headers to expose
+ * @param    {Array} [options.preflightMaxAge] ms to cache preflight requests
+ * @param    {Object | Function | Boolean} [options.preflightStrategy]
+ * customize preflight request handling
+ * @returns  {Object} returns an object with a handler and preflight handler
  */
-function cors(options) {
-    assert.optionalObject(options, 'options');
+function createCorsContext(options) {
+
+    assert.object(options, 'options');
+    assert.optionalArrayOfString(options.origins, 'options.origins');
+    assert.optionalBool(options.credentials, 'options.credentials');
+    assert.optionalArrayOfString(options.exposeHeaders,
+                                 'options.exposeHeaders');
+    assert.optionalArrayOfString(options.allowHeaders, 'options.allowHeaders');
+    assert.optionalNumber(options.preflightMaxAge, 'options.preflightMaxAge');
+
     var opts = options || {};
-    assert.optionalArrayOfString(opts.origins, 'options.origins');
-    assert.optionalBool(opts.credentials, 'options.credentials');
-    assert.optionalArrayOfString(opts.headers, 'options.headers');
-
-    cors.credentials = opts.credentials;
-    cors.origins = opts.origins || ['*'];
-
-    var headers = (opts.headers || []).slice(0);
+    var credentials = opts.credentials || false;
     var origins = opts.origins || ['*'];
+    var allowHeaders = opts.allowHeaders || [];
+    var exposeHeaders = opts.exposeHeaders || [];
+    var preflightMaxAge = opts.preflightMaxAge || AC_MAX_AGE_MS;
+    var preflightStrategy = opts.preflightStrategy;
 
+    // concat customized headers to the default list
     EXPOSE_HEADERS.forEach(function (h) {
-        if (headers.indexOf(h) === -1) {
-            headers.push(h);
+        if (exposeHeaders.indexOf(h) === -1) {
+            exposeHeaders.push(h);
         }
     });
 
-    // Handler for simple requests
-    function restifyCORSSimple(req, res, next) {
-        var origin;
+    ALLOW_HEADERS.forEach(function (h) {
+        if (allowHeaders.indexOf(h) === -1) {
+            allowHeaders.push(h);
+        }
+    });
 
-        if (!(origin = matchOrigin(req, origins))) {
-            next();
-            return;
+
+    // use the preflight spec from w3
+    // http://www.w3.org/TR/cors/#access-control-request-headers-request-header
+    function preflight(req, res, next) {
+
+        // 1) if not an options request, move on.
+        if (req.method !== 'OPTIONS') {
+            return next();
         }
 
-        function corsOnHeader() {
-            origin = req.headers.origin;
+        // now check the preflight requirements are all available. if anything
+        // is missing, or the resource requested for is missing, returna 400.
+        var reqOrigin = req.headers.origin;
+        var reqMethod = req.headers[AC_REQ_METHOD];
+        var reqHeaders = req.headers[AC_REQ_HEADERS];
+        var errMsg = 'invalid preflight request';
+        var errMsg2 = 'unsupported method';
 
-            if (opts.credentials) {
-                res.setHeader(AC_ALLOW_ORIGIN, origin);
-                res.setHeader(AC_ALLOW_CREDS, 'true');
-            } else {
-                res.setHeader(AC_ALLOW_ORIGIN, origin);
+        // 2) check that the incoming preflight headers are ok
+        if (!reqOrigin || !reqMethod || !reqHeaders) {
+            return next(new errs.BadRequestError(errMsg));
+        }
+
+        // 3.1) check if origin is valid and matched
+        var matchedOrigin = matchOrigin(reqOrigin, origins);
+        // 3.2) make sure headers are all allowed
+        var splitHeaders = reqHeaders.split(/\s*,\s*/);
+        var validHeaders = splitHeaders.every(function headerOk(h) {
+            return (allowHeaders.indexOf(h) !== -1);
+        });
+
+        // if either 3.1 or 3.2 failed, return 400.
+        if (!matchedOrigin || !validHeaders) {
+            return next(new errs.BadRequestError(errMsg));
+        }
+
+        // 3.4) check that the requested resource and method are valid. couple
+        // ways we can do this. user passes in an option that can either be:
+        //
+        //  - a restify server instance:
+        //      in this scenario, we use the router to 'simulate' a routing
+        //      request, which will populate res.methods with the supported
+        //      methods for that resource. this is an easy way to
+        //      automatically get full support without having to implement
+        //      server.opts on every single cors resource.
+        //
+        //      on a successful 'route', the router will populate
+        //      res.methods with the list of supported methods, and also
+        //      likely return a 405, but that's expected. iif router returns
+        //      a 404, that means the resource doesn't even exist, so we
+        //      need to send a 400 back.
+        //
+        //  - a function, that given req/res, returns an array of methods
+        //      a user provided function that will return an array of supported
+        //      methods given a req and res object.
+        //
+        //  - a value of false
+        //      don't do anything, user will manually implement server.opts for
+        //      every single resource.
+
+        var findMethodsFn;
+
+        if (typeof preflightStrategy === 'function') {
+            findMethodsFn = preflightStrategy;
+        } else if (typeof preflightStrategy === 'object' &&
+                   preflightStrategy.router &&
+                   preflightStrategy.router.find) {
+
+            var server = preflightStrategy;
+            findMethodsFn = function findMethods() {
+                // anonymouns fn to avoid bind here
+                var args = [].slice.apply(arguments);
+                server.router.find.apply(server.router, args);
+            };
+        } else {
+            findMethodsFn = function noop(_, _2, cb) {
+                return cb();
+            };
+        }
+
+        // restify router has a sig of function found(err, route, context) {
+        // but we don't use route or context in this case. for simplicity
+        // sake, the user facing preflightStrategy should just return an
+        // array of methods as the second param.
+        findMethodsFn(req, res, function found(err, resMethods) {
+
+            if (err) {
+                if (err instanceof errs.ResourceNotFoundError ||
+                    err.restCode === 'ResourceNotFound') {
+                    return next(new errs.BadRequestError(errMsg));
+                }
             }
 
-            res.setHeader(AC_EXPOSE_HEADERS, headers.join(', '));
-        }
+            // look for it first on res, then on the returned value, then
+            // finally fall back to empty array
+            var supportedMethods = res.methods || resMethods || [];
 
-        res.once('header', corsOnHeader);
-        next();
+            // ensure the requested method is within this list of supported
+            // methods.
+            if (supportedMethods.indexOf(reqMethod) === -1) {
+                return next(new errs.MethodNotAllowedError(errMsg2));
+            }
+
+            // the request looks good. set headers and we're good to go.
+            setCommonHeaders(res, reqOrigin, matchedOrigin);
+            res.setHeader(AC_ALLOW_HEADERS, allowHeaders.join(', '));
+            res.setHeader(AC_ALLOW_METHODS, supportedMethods);
+            res.setHeader(AC_MAX_AGE, preflightMaxAge);
+
+            // end the request, return false so restify will stop processing
+            // the request.
+            res.writeHead(200);
+            res.end();
+            return next(false);
+        });
     }
 
-    return (restifyCORSSimple);
+
+
+    // sets headers for use in CORS requests
+    function headers(req, res, next) {
+
+        // 1) if no origin header incoming request, move on, set no headers.
+        var reqOrigin = req.headers.origin;
+
+        if (!reqOrigin) {
+            return next();
+        }
+
+        // 2) if no matched origin found, move on, set no headers.
+        var matchedOrigin = matchOrigin(reqOrigin, origins);
+
+        if (!matchedOrigin) {
+            return next();
+        }
+
+        // if match was found, let's set some headers.
+        setCommonHeaders(res, reqOrigin, matchedOrigin);
+        res.setHeader(AC_EXPOSE_HEADERS, exposeHeaders.join(', '));
+
+        return next();
+    }
+
+
+    // set common cors headers
+    function setCommonHeaders(res, reqOrigin, matchedOrigin) {
+        if (credentials === true) {
+            // when credentials are used, not allowed to use *!
+            res.setHeader(AC_ALLOW_ORIGIN, reqOrigin);
+            res.setHeader(AC_ALLOW_CREDS, 'true');
+            res.setHeader(STR_VARY, STR_ORIGIN);
+        } else {
+            // for non credentialed requests
+            if (matchedOrigin === '*') {
+                res.setHeader(AC_ALLOW_ORIGIN, '*');
+            } else {
+                res.setHeader(AC_ALLOW_ORIGIN, matchedOrigin);
+                res.setHeader(STR_VARY, STR_ORIGIN);
+            }
+        }
+    }
+
+
+    // finally, export the payload
+    var payload = {
+        headers: headers
+    };
+
+    // only add a preflight function to the exports if a strategy was provided.
+    if (preflightStrategy) {
+        payload.preflight = preflight;
+    }
+
+    return payload;
 }
 
 
 ///--- Exports
 
-module.exports = cors;
-
-// All of these are needed for the pre-flight code over in lib/router.js
-cors.ALLOW_HEADERS = ALLOW_HEADERS;
-cors.EXPOSE_HEADERS = EXPOSE_HEADERS;
-cors.credentials = false;
-cors.origins = [];
-cors.matchOrigin = matchOrigin;
+module.exports = createCorsContext;

--- a/lib/plugins/cors.js
+++ b/lib/plugins/cors.js
@@ -44,13 +44,37 @@ var STR_ORIGIN = 'origin';
 
 ///--- Internal Functions
 
+
+/**
+ * turn potential string patterns into regexps.
+ * @private
+ * @function toRegExp
+ * @param {String} str an input string
+ * @returns {RegExp}
+ */
+function toRegExp(str) {
+
+    if (str instanceof RegExp || str === '*') {
+        return str;
+    }
+
+    var regexStr = str
+        // escape all the special characters, except *
+        .replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&')
+        // replace all instances of * with a proper regex wildcard
+        .replace(/\*/g, '.*');
+
+    return new RegExp('^(https?://)?' + regexStr + '$', 'i');
+}
+
+
 /**
  * find a possible match given an incoming origin header against an array of
  * known whitelisted origins.
  * @private
  * @function matchOrigin
  * @param {String} incomingOrigin the incoming origin header
- * @param {Array} origins an array of origin strings
+ * @param {Array} origins an array of origin regexps
  * @returns {String | Boolean}
  */
 function matchOrigin(incomingOrigin, origins) {
@@ -59,8 +83,11 @@ function matchOrigin(incomingOrigin, origins) {
 
     if (incomingOrigin) {
         origins.some(function belong(o) {
-            if (o === incomingOrigin || o === '*') {
+            if (o === '*') {
                 matched = o;
+                return true;
+            } else if (o.test(incomingOrigin)) {
+                matched = incomingOrigin;
                 return true;
             }
             return false;
@@ -100,14 +127,13 @@ function matchOrigin(incomingOrigin, origins) {
  * @param    {Array} [options.allowHeaders] user defined headers to allow
  * @param    {Array} [options.exposeHeaders] user defined headers to expose
  * @param    {Array} [options.preflightMaxAge] ms to cache preflight requests
- * @param    {Object | Function | Boolean} [options.preflightStrategy]
+ * @param    {Object | Function} [options.preflightStrategy]
  * customize preflight request handling
  * @returns  {Object} returns an object with a handler and preflight handler
  */
 function createCorsContext(options) {
 
     assert.object(options, 'options');
-    assert.optionalArrayOfString(options.origins, 'options.origins');
     assert.optionalBool(options.credentials, 'options.credentials');
     assert.optionalArrayOfString(options.exposeHeaders,
                                  'options.exposeHeaders');
@@ -116,11 +142,20 @@ function createCorsContext(options) {
 
     var opts = options || {};
     var credentials = opts.credentials || false;
-    var origins = opts.origins || ['*'];
+    // convert all origin values into regexps. however, leave '*' as is for
+    // easier grokking later.
+    var origins = (opts.origins || ['*']).map(toRegExp);
     var allowHeaders = opts.allowHeaders || [];
     var exposeHeaders = opts.exposeHeaders || [];
     var preflightMaxAge = opts.preflightMaxAge || AC_MAX_AGE_MS;
     var preflightStrategy = opts.preflightStrategy;
+
+    // assert origin patterns, everything should be a regexp unless it's a *
+    assert.array(origins, 'origins');
+    origins.forEach(function (o) {
+        assert.ok(o === '*' || o instanceof RegExp, o +
+                  ' is not a valid origin');
+    });
 
     // concat customized headers to the default list
     EXPOSE_HEADERS.forEach(function (h) {
@@ -160,6 +195,7 @@ function createCorsContext(options) {
 
         // 3.1) check if origin is valid and matched
         var matchedOrigin = matchOrigin(reqOrigin, origins);
+
         // 3.2) make sure headers are all allowed
         var splitHeaders = reqHeaders.split(/\s*,\s*/);
         var validHeaders = splitHeaders.every(function headerOk(h) {

--- a/lib/plugins/fullResponse.js
+++ b/lib/plugins/fullResponse.js
@@ -6,51 +6,11 @@ var crypto = require('crypto');
 var httpDate = require('../utils/httpDate');
 
 
-///--- Globals
-
-var ALLOW_HEADERS = [
-    'Accept',
-    'Accept-Version',
-    'Content-Length',
-    'Content-MD5',
-    'Content-Type',
-    'Date',
-    'Api-Version',
-    'Response-Time'
-].join(', ');
-
-var EXPOSE_HEADERS = [
-    'Api-Version',
-    'Request-Id',
-    'Response-Time'
-].join(', ');
-
-
 ///--- API
 
 function setHeaders(req, res) {
     var hash;
     var now = new Date();
-    var methods;
-
-    if (!res.getHeader('Access-Control-Allow-Origin')) {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-    }
-
-    if (!res.getHeader('Access-Control-Allow-Headers')) {
-        res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
-    }
-
-    if (!res.getHeader('Access-Control-Allow-Methods')) {
-        if (res.methods && res.methods.length > 0) {
-            methods = res.methods.join(', ');
-            res.setHeader('Access-Control-Allow-Methods', methods);
-        }
-    }
-
-    if (!res.getHeader('Access-Control-Expose-Headers')) {
-        res.setHeader('Access-Control-Expose-Headers', EXPOSE_HEADERS);
-    }
 
     if (!res.getHeader('Connection')) {
         res.setHeader('Connection',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "Quentin Buathier",
     "Ricardo Stuven",
     "Scott Turnquest",
+    "Stefano Dalpiaz",
     "Tim Kuijsten",
     "Trent Mick",
     "Tuure Kanuisto",

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,311 @@
+'use strict';
+
+// core modules
+var http = require('http');
+
+// external modules
+var assert = require('chai').assert;
+var restify = require('restify');
+var restifyClients = require('restify-clients');
+
+// local files
+var plugins = require('../lib');
+var helper = require('./lib/helper');
+
+// local globals
+var PORT = process.env.UNIT_TEST_PORT || 0;
+var CLIENT;
+var SERVER;
+var AC_ALLOW_CREDS = 'access-control-allow-credentials';
+var AC_ALLOW_ORIGIN = 'access-control-allow-origin';
+var AC_MAX_AGE = 'access-control-max-age';
+
+
+
+function setupCors(options) {
+    var cors = plugins.cors(options);
+    SERVER.pre(cors.preflight);
+    SERVER.use(cors.headers);
+}
+
+
+function preflight(options, callback) {
+
+    var opts = {
+        hostname: '127.0.0.1',
+        port: PORT,
+        path: options.path || '/foo/bar',
+        method: 'OPTIONS',
+        agent: false,
+        headers: options.headers
+    };
+
+    http.request(opts, callback).end();
+}
+
+
+describe('CORS', function () {
+
+    beforeEach(function (done) {
+        SERVER = restify.createServer({
+            dtrace: helper.dtrace,
+            log: helper.getLog('server'),
+            version: ['2.0.0', '0.5.4', '1.4.3']
+        });
+        SERVER.post('/foo/:id', function tester (req, res, next) {});
+        SERVER.listen(PORT, '127.0.0.1', function () {
+            PORT = SERVER.address().port;
+            CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                dtrace: helper.dtrace,
+                retry: false
+            });
+
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        CLIENT.close();
+        SERVER.close(done);
+    });
+
+
+    describe('preflight', function () {
+
+        it('should return host for matching origin', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN],
+                             'http://somesite.local');
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should return * for any origin', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local', '*' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://anysite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN], '*');
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should return 400 for non matching origin', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://anysite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 400);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN], undefined);
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should return 400 for unsupported resource', function (done) {
+
+            setupCors({
+                credentials: true,
+                origins: [ 'http://somesite.local' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'GET',
+                    Origin: 'http://somesite.local'
+                },
+                path: '/bar/baz'
+            }, function (res) {
+                assert.equal(res.statusCode, 400);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN], undefined);
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should return 405 for unsupported method', function (done) {
+
+            setupCors({
+                credentials: true,
+                origins: [ 'http://somesite.local' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'GET',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 405);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN], undefined);
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should not return * for credentialed request', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                credentials: true,
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN],
+                             'http://somesite.local');
+                assert.equal(res.headers[AC_ALLOW_CREDS], 'true');
+                done();
+            });
+
+        });
+
+        it('should return 400 for headers not in whitelist', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                credentials: true,
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type,' +
+                                                      ' x-foobar',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 400);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN], undefined);
+                assert.equal(res.headers[AC_ALLOW_CREDS], undefined);
+                done();
+            });
+        });
+
+        it('should return 200 for headers in whitelist', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                credentials: true,
+                preflightStrategy: SERVER,
+                allowHeaders: ['x-foobar']
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type,' +
+                                                      ' x-foobar',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN],
+                             'http://somesite.local');
+                assert.equal(res.headers[AC_ALLOW_CREDS], 'true');
+                done();
+            });
+        });
+
+        it('should default to 5 min preflight cache timeout', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN],
+                             'http://somesite.local');
+                assert.equal(res.headers[AC_MAX_AGE], 3600);
+                done();
+            });
+        });
+
+        it('should set custom preflight cache timeout', function (done) {
+
+            setupCors({
+                origins: [ 'http://somesite.local' ],
+                preflightMaxAge: 1000,
+                preflightStrategy: SERVER
+            });
+
+            preflight({
+                headers: {
+                    'Access-Control-Request-Headers': 'accept, content-type',
+                    'Access-Control-Request-Method': 'POST',
+                    Origin: 'http://somesite.local'
+                }
+            }, function (res) {
+                assert.equal(res.statusCode, 200);
+                assert.equal(res.headers[AC_ALLOW_ORIGIN],
+                             'http://somesite.local');
+                assert.equal(res.headers[AC_MAX_AGE], 1000);
+                done();
+            });
+        });
+    });
+
+
+    describe('cors headers', function () {
+
+
+
+
+
+    });
+});

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -117,10 +117,6 @@ describe('all other plugins', function () {
                 assert.equal(res.statusCode, 200);
                 var headers = res.headers;
                 assert.ok(headers, 'headers ok');
-                assert.ok(headers['access-control-allow-origin']);
-                assert.ok(headers['access-control-allow-headers']);
-                assert.ok(headers['access-control-expose-headers']);
-                assert.ok(headers['access-control-allow-methods']);
                 assert.ok(headers.date);
                 assert.ok(headers['request-id']);
                 assert.ok(headers['response-time'] >= 0);


### PR DESCRIPTION
Got bored and decided to refactor cors. This fixes a slew of CORS related issues and attempts to make it a little more sane/configurable. Attempts to fix and address all of the following issues and PRs:

Issues:
restify/node-restify#391
restify/node-restify#573
restify/node-restify#664
restify/node-restify#950

PRs:
[node-restify#600](https://github.com/restify/node-restify/pull/600)
[node-restify#609](https://github.com/restify/node-restify/pull/609)

I'm sure there's more I haven't found. In short:
- refactored CORS to now be decoupled from restify core
- CORS plugin now returns two handlers, one for pre and one for use
- removes CORS related headers from fullResponse plugin
- allow customization of whitelisted headers
- allow customization of exposed headers to client
- allow creation of multiple CORS handlers to use independently on different endpoints (no more shared global state), so you can enable CORS on a per resource basis if needed

The tests may fail until the accompanying restify/node-restify#985 is merged.
