### PR TITLE
add optional feature to check modified file modified time to return 304

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The module includes the following response plugins:
 * `gzip(options)` - gzips the response if client accepts it
   * `options` {Object} options to pass to zlib
 * `serveStatic()` - used to serve static files
+  * `options.checkIfModified` {Boolean} if true, will check file modified date to send a 304.
 * `throttle(options)` - throttles responses
   * `options.burst` {Number}
   * `options.rate` {Number}

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -72,10 +72,12 @@ function serveStatic(options) {
             res.set('ETag', opts.etag(stats, opts));
         }
 
+        var requestTime;
+        var modifiedTime;
         try {
             if(opts.checkIfModified){
-                var requestTime = Date.parse(req.header('if-modified-since')) || 0;
-                var modifiedTime = Date.parse(stats.mtime);
+                requestTime = Date.parse(req.header('if-modified-since')) || 0;
+                modifiedTime = Date.parse(stats.mtime);
             }
         } catch(e){
             opts.checkIfModified=false;

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -38,6 +38,7 @@ function serveStatic(options) {
     assert.optionalObject(opts.match, 'options.match');
     assert.optionalString(opts.charSet, 'options.charSet');
     assert.optionalString(opts.file, 'options.file');
+    assert.optionalBool(opts.checkIfModified, 'options.checkIfModified');
 
     var p = path.normalize(opts.directory).replace(/\\/g, '/');
     var re = new RegExp('^' + escapeRE(p) + '/?.*');
@@ -55,29 +56,45 @@ function serveStatic(options) {
             res.handledGzip();
         }
 
-        var fstream = fs.createReadStream(file + (isGzip ? '.gz' : ''));
         var maxAge = opts.maxAge === undefined ? 3600 : opts.maxAge;
-        fstream.once('open', function (fd) {
-            res.cache({maxAge: maxAge});
-            res.set('Content-Length', stats.size);
-            res.set('Content-Type', mime.lookup(file));
-            res.set('Last-Modified', stats.mtime);
+        res.cache({maxAge: maxAge});
+        res.set('Content-Length', stats.size);
+        res.set('Content-Type', mime.lookup(file));
+        res.set('Last-Modified', stats.mtime);
 
-            if (opts.charSet) {
-                var type = res.getHeader('Content-Type') +
-                    '; charset=' + opts.charSet;
-                res.setHeader('Content-Type', type);
-            }
+        if (opts.charSet) {
+            var type = res.getHeader('Content-Type') +
+                '; charset=' + opts.charSet;
+            res.setHeader('Content-Type', type);
+        }
 
-            if (opts.etag) {
-                res.set('ETag', opts.etag(stats, opts));
+        if (opts.etag) {
+            res.set('ETag', opts.etag(stats, opts));
+        }
+
+        try {
+            if(opts.checkIfModified){
+                var requestTime = Date.parse(req.header('if-modified-since')) || 0;
+                var modifiedTime = Date.parse(stats.mtime);
             }
-            res.writeHead(200);
-            fstream.pipe(res);
-            fstream.once('end', function () {
-                next(false);
+        } catch(e){
+            opts.checkIfModified=false;
+        }
+
+        if(opts.checkIfModified && requestTime && modifiedTime<=requestTime
+            && (req.method === 'GET' || req.method === 'HEAD')) {
+            res.send(304);
+            next(false);
+        } else {
+            var fstream = fs.createReadStream(file + (isGzip ? '.gz' : ''));
+            fstream.once('open', function (fd) {
+                res.writeHead(200);
+                fstream.pipe(res);
+                fstream.once('end', function () {
+                    next(false);
+                });
             });
-        });
+        }
     }
 
     function serveNormal(file, req, res, next) {

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -74,16 +74,17 @@ function serveStatic(options) {
 
         var requestTime;
         var modifiedTime;
+
         try {
-            if(opts.checkIfModified){
+            if (opts.checkIfModified) {
                 requestTime = Date.parse(req.header('if-modified-since')) || 0;
                 modifiedTime = Date.parse(stats.mtime);
             }
-        } catch(e){
-            opts.checkIfModified=false;
+        } catch (e) {
+            opts.checkIfModified = false;
         }
 
-        if(opts.checkIfModified && requestTime && modifiedTime<=requestTime
+        if (opts.checkIfModified && requestTime && modifiedTime <= requestTime
             && (req.method === 'GET' || req.method === 'HEAD')) {
             res.send(304);
             next(false);


### PR DESCRIPTION
https://github.com/restify/node-restify/pull/994

https://github.com/restify/plugins/pull/17
@Dzitu what version of windows return milliseconds? My Windows 7 always ends with `000` meaning it's only accurate to seconds.
