### PR TITLE
(serveStatic plugin) Serve default file when no file matches

### DIFF
--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -38,6 +38,7 @@ function serveStatic(options) {
     assert.optionalObject(opts.match, 'options.match');
     assert.optionalString(opts.charSet, 'options.charSet');
     assert.optionalString(opts.file, 'options.file');
+    assert.optionalString(opts.default, 'options.default');
 
     var p = path.normalize(opts.directory).replace(/\\/g, '/');
     var re = new RegExp('^' + escapeRE(p) + '/?.*');

--- a/lib/plugins/static.js
+++ b/lib/plugins/static.js
@@ -44,8 +44,13 @@ function serveStatic(options) {
 
     function serveFileFromStats(file, err, stats, isGzip, req, res, next) {
         if (err) {
-            next(new ResourceNotFoundError(err, '%s', req.path()));
-            return;
+            var defaultFile = path.join(opts.directory, opts.default);
+            if (opts.default && file !== defaultFile) {
+                return serveNormal(defaultFile, req, res, next);
+            } else {
+                next(new ResourceNotFoundError(err, '%s', req.path()));
+                return;
+            }
         } else if (!stats.isFile()) {
             next(new ResourceNotFoundError('%s does not exist', req.path()));
             return;


### PR DESCRIPTION
I ran into the same issue as #13 and was expecting the serveStatic plugin to server the default file if there wasn't a match in the file system, which is what the documentation implies.

This PR inserts a check to see if a default file was specified and to try and serve that instead of returning ResourceNotFound. There is also a check to make sure that we do send ResourceNotFound is the default file doesn't exist. This makes the serveStatic plugin match what the documentation describes.
