### PR TITLE
GH-35: new dedupeSlashes plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ module.exports = {
     pre: {
         pause: require('./pre/pause'),
         sanitizePath: require('./pre/prePath'),
-        userAgentConnection: require('./pre/userAgent')
+        userAgentConnection: require('./pre/userAgent'),
+        dedupeSlashes: require('./pre/dedupeSlashes')
     }
 };

--- a/lib/pre/dedupeSlashes.js
+++ b/lib/pre/dedupeSlashes.js
@@ -1,0 +1,12 @@
+'use strict';
+
+
+function createDedupeSlashes() {
+    return function dedupeSlashes(req, res, next) {
+        req.url = req.url.replace(/(\/)\/+/g, '$1');
+        return next();
+    };
+}
+
+
+module.exports = createDedupeSlashes;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
     "nsp": "^2.4.0",
-    "restify": "^4.0.3",
+    "restify": "git+https://git@github.com/restify/node-restify.git#5.x",
     "restify-clients": "^1.1.1",
     "rimraf": "^2.4.3"
   },

--- a/test/dedupeSlashes.js
+++ b/test/dedupeSlashes.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// external requires
+var assert = require('chai').assert;
+var restify = require('restify');
+var restifyClients = require('restify-clients');
+
+// local files
+var helper = require('./lib/helper');
+var plugins = require('../lib');
+
+// local globals
+var SERVER;
+var CLIENT;
+var PORT;
+
+
+describe('dedupe forward slashes in URL', function () {
+
+    describe('non-strict routing', function () {
+
+        before(function (done) {
+            SERVER = restify.createServer({
+                dtrace: helper.dtrace,
+                log: helper.getLog('server')
+            });
+
+            SERVER.pre(plugins.pre.dedupeSlashes());
+
+            SERVER.get('/foo/bar', function respond(req, res, next) {
+                res.send(req.url);
+                next();
+            });
+
+            SERVER.listen(0, '127.0.0.1', function () {
+                PORT = SERVER.address().port;
+                CLIENT = restifyClients.createJsonClient({
+                    url: 'http://127.0.0.1:' + PORT,
+                    dtrace: helper.dtrace,
+                    retry: false
+                });
+
+                done();
+            });
+        });
+
+        after(function (done) {
+            CLIENT.close();
+            SERVER.close(done);
+        });
+
+        it('should not remove single slashes', function (done) {
+            CLIENT.get('/foo/bar', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar');
+                done();
+            });
+        });
+
+        it('should not remove single slashes including trailing slashes',
+        function (done) {
+            CLIENT.get('/foo/bar/', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar/');
+                done();
+            });
+        });
+
+        it('should remove duplicate slashes', function (done) {
+            CLIENT.get('//foo//bar', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar');
+                done();
+            });
+        });
+
+        it('should remove duplicate slashes including trailing slashes',
+        function (done) {
+            CLIENT.get('//foo//bar//', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar/');
+                done();
+            });
+        });
+    });
+
+
+
+    describe('strict routing', function () {
+
+        before(function (done) {
+            SERVER = restify.createServer({
+                strictRouting: true,
+                dtrace: helper.dtrace,
+                log: helper.getLog('server')
+            });
+
+            SERVER.pre(plugins.pre.dedupeSlashes());
+
+            SERVER.get('/foo/bar/', function respond(req, res, next) {
+                res.send(req.url);
+                next();
+            });
+
+            SERVER.listen(0, '127.0.0.1', function () {
+                PORT = SERVER.address().port;
+                CLIENT = restifyClients.createJsonClient({
+                    url: 'http://127.0.0.1:' + PORT,
+                    dtrace: helper.dtrace,
+                    retry: false
+                });
+
+                done();
+            });
+        });
+
+        after(function (done) {
+            CLIENT.close();
+            SERVER.close(done);
+        });
+
+        it('should not remove single slashes', function (done) {
+            CLIENT.get('/foo/bar/', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar/');
+                done();
+            });
+        });
+
+        it('should remove duplicate slashes', function (done) {
+            CLIENT.get('//foo//bar//', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar/');
+                done();
+            });
+        });
+
+
+        it('should remove duplicate slashes including trailing slashes',
+        function (done) {
+            CLIENT.get('//foo//bar//', function (err, _, res, data) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.equal(data, '/foo/bar/');
+                done();
+            });
+        });
+    });
+});
+
+


### PR DESCRIPTION
This requires restify 5.x for the new strictRouting options. We'll probably do a fast release after we publish restify 5.x. 

This plugin comes out of the discussion in restify/node-restify#1092. 
