### PR TITLE
Allow to configure QueryParser with all qs options

### DIFF
--- a/lib/plugins/query.js
+++ b/lib/plugins/query.js
@@ -28,7 +28,7 @@ function queryParser(options) {
             return next();
         }
 
-        req.query = qs.parse(req.getQuery());
+        req.query = qs.parse(req.getQuery(), opts);
 
         if (opts.mapParams === true) {
             Object.keys(req.query).forEach(function (k) {


### PR DESCRIPTION
qs provides several options to parse query.
Now you can benefit of these options by using QueryParser options.
