### PR TITLE
added partial support for client initiated content encoding (RFC 7694)

### DIFF
--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -14,6 +14,7 @@ var errors = require('restify-errors');
 var BadDigestError = errors.BadDigestError;
 var RequestEntityTooLargeError = errors.RequestEntityTooLargeError;
 var PayloadTooLargeError = errors.PayloadTooLargeError;
+var UnsupportedMediaTypeError = errors.UnsupportedMediaTypeError;
 
 var MD5_MSG = 'Content-MD5 \'%s\' didn\'t match \'%s\'';
 
@@ -81,12 +82,18 @@ function bodyReader(options) {
         var hash;
         var md5;
 
+        var unsupportedCompression;
+
         if ((md5 = req.headers['content-md5'])) {
             hash = crypto.createHash('md5');
         }
 
         function done() {
             bodyWriter.end();
+
+            if (unsupportedCompression) {
+                next(new UnsupportedMediaTypeError('Unsupported compression type ' + unsupportedCompression));
+            }
 
             if (maxBodySize && bytesReceived > maxBodySize) {
                 var msg = 'Request body size exceeds ' + maxBodySize;
@@ -124,6 +131,8 @@ function bodyReader(options) {
             gz.once('end', done);
             req.once('end', gz.end.bind(gz));
         } else {
+            unsupportedCompression = req.headers['content-encoding'];
+            res.setHeader('Accept-Encoding', 'gzip');
             req.once('end', done);
         }
 

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -125,7 +125,10 @@ function bodyReader(options) {
             next();
         }
 
-        if (req.headers['content-encoding'] === 'gzip') {
+        if (req.headers['content-encoding'] === undefined) {
+            // This handles the original else branch
+            req.once('end', done);
+        } else if (req.headers['content-encoding'] === 'gzip') {
             gz = zlib.createGunzip();
             gz.on('data', bodyWriter.write);
             gz.once('end', done);

--- a/test/bodyReader.js
+++ b/test/bodyReader.js
@@ -1,0 +1,116 @@
+'use strict';
+
+// core requires
+
+// external requires
+var assert = require('chai').assert;
+var restify = require('restify');
+var restifyClients = require('restify-clients');
+
+// local files
+var helper = require('./lib/helper');
+var plugins = require('../lib');
+
+// local globals
+var SERVER;
+var CLIENT;
+var PORT;
+
+
+describe('body reader', function () {
+
+    describe('gzip content encoding', function () {
+
+        beforeEach(function (done) {
+            SERVER = restify.createServer({
+                dtrace: helper.dtrace,
+                log: helper.getLog('server')
+            });
+
+            SERVER.listen(0, '127.0.0.1', function () {
+                PORT = SERVER.address().port;
+
+                done();
+            });
+        });
+
+        afterEach(function (done) {
+            CLIENT.close();
+            SERVER.close(done);
+        });
+
+        it('should parse gzip encoded content', function (done) {
+            SERVER.use(plugins.bodyParser());
+            
+            CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                retry: false,
+                gzip: {}
+            });
+
+            SERVER.post('/compressed', function (req, res, next) {
+                assert.equal(req.body.apple, 'red');
+                res.send();
+                next();
+            });
+
+            CLIENT.post('/compressed', {
+                apple: 'red'
+            }, function (err, _, res) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                done();
+            });
+        });
+
+        it('should not accept unsupported content encoding', function (done) {
+            SERVER.use(plugins.bodyParser());
+
+            CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                retry: false,
+                headers: {
+                  'content-encoding': 'unsupported'
+                }
+            });
+
+            SERVER.post('/compressed', function (req, res, next) {
+                assert.equal(req.body.apple, 'red');
+                res.send();
+                next();
+            });
+
+            CLIENT.post('/compressed', {
+                apple: 'red'
+            }, function (err, _, res) {
+                assert.equal(res.statusCode, 415);
+                assert.equal(res.headers['accept-encoding'], 'gzip');
+                done();
+            });
+        });
+
+        it('should parse unencoded content', function (done) {
+            SERVER.use(plugins.bodyParser());
+            
+            CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                retry: false
+            });
+
+            SERVER.post('/compressed', function (req, res, next) {
+                assert.equal(req.body.apple, 'red');
+                res.send();
+                next();
+            });
+
+            CLIENT.post('/compressed', {
+                apple: 'red'
+            }, function (err, _, res) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                done();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
This PR implements partial support for [RFC 7694 Hypertext Transfer Protocol (HTTP) Client-Initiated Content-Encoding](https://tools.ietf.org/html/rfc7694), more specifically this interaction:

>    A client submits a POST request using the "compress" content coding
>    ([RFC7231], Section 3.1.2.1):
> 
>      POST /edit/ HTTP/1.1
>      Host: example.org
>      Content-Type: application/atom+xml;type=entry
>      Content-Encoding: compress
> 
>      ...compressed payload...
> 
>    The server rejects the request because it only allows the "gzip"
>    content coding:
> 
>      HTTP/1.1 415 Unsupported Media Type
>      Date: Fri, 09 May 2014 11:43:53 GMT
>      Accept-Encoding: gzip
>      Content-Length: 68
>      Content-Type: text/plain
> 
>      This resource only supports the "gzip" content coding in requests.

I have looked for `bodyReader` tests but could not find them.