### PR TITLE
Add context pre plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-   - "0.10"
-   - "0.12"
    - "4"
    - "6"
 script: make prepush

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
    - "0.10"
    - "0.12"
    - "4"
+   - "6"
+script: make prepush
 notifications:
   webhooks:
     urls:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This module includes the follow `pre` plugins, which are intended to be used
 prior to the routing of a request:
 
 * `sanitizePath()` - cleans up duplicate or trailing / on the URL
+* `context()` - Provide req.set(key, val) and req.get(key) methods for setting and retrieving context to a specific request.
 * `userAgent(options)` - used to support edge cases for HEAD requests when using curl
   * `options.userAgentRegExp` {RegExp} regexp to capture curl user-agents
 * `strictQueryParams()` - checks req.urls query params with strict key/val format and rejects non-strict requests with status code 400.

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,10 +26,11 @@ module.exports = {
     oauth2TokenParser: require('./plugins/oauth2TokenParser'),
 
     pre: {
+        context: require('./pre/context'),
+        dedupeSlashes: require('./pre/dedupeSlashes'),
         pause: require('./pre/pause'),
         sanitizePath: require('./pre/prePath'),
-        userAgentConnection: require('./pre/userAgent'),
         strictQueryParams: require('./pre/strictQueryParams'),
-        dedupeSlashes: require('./pre/dedupeSlashes')
+        userAgentConnection: require('./pre/userAgent')
     }
 };

--- a/lib/pre/context.js
+++ b/lib/pre/context.js
@@ -17,9 +17,15 @@ function ctx() {
         req.set = function set(key, value) {
             data[key] = value;
         };
+
         req.get = function get(key) {
             return data[key];
         };
+
+        // private method which returns the entire context object
+        req._getAllContext = function _getAllContext() {
+            return data;
+        }
 
         return next();
     };

--- a/lib/pre/context.js
+++ b/lib/pre/context.js
@@ -1,0 +1,31 @@
+// Copyright 2016 Restify. All rights reserved.
+
+'use strict';
+
+
+///--- API
+
+/**
+ * Provides req.set() and req.get() methods for handlers to share context
+ * across the lifetime of a request.
+ *
+ * @returns {Function}
+ */
+function ctx() {
+    var data = {};
+    return function context(req, res, next) {
+        req.set = function set(key, value) {
+            data[key] = value;
+        };
+        req.get = function get(key) {
+            return data[key];
+        };
+
+        return next();
+    };
+}
+
+
+///--- Exports
+
+module.exports = ctx;

--- a/lib/pre/context.js
+++ b/lib/pre/context.js
@@ -25,7 +25,7 @@ function ctx() {
         // private method which returns the entire context object
         req._getAllContext = function _getAllContext() {
             return data;
-        }
+        };
 
         return next();
     };

--- a/lib/pre/strictQueryParams.js
+++ b/lib/pre/strictQueryParams.js
@@ -36,11 +36,12 @@ function strictQueryParams(options) {
         var keyValQParams = !/(\&(?!(\w+=\w+)))/.test(req.url);
 
         if (!keyValQParams) {
-            var msg = opts.message ? opts.message : 'Url query params does not meet strict format';
+            var msg = opts.message ? opts.message :
+                'Url query params does not meet strict format';
             return next(new BadRequestError(msg));
         }
 
-        next();
+        return next();
     }
 
     return (_strictQueryParams);

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -138,6 +138,9 @@ describe('all other plugins', function () {
             SERVER.pre(plugins.pre.context());
 
             var asserted = false;
+            var expectedData = {
+                pink: 'floyd'
+            }
             SERVER.get('/context', [
                 function (req, res, next) {
                     req.set('pink', 'floyd');
@@ -145,6 +148,7 @@ describe('all other plugins', function () {
                 },
                 function (req, res, next) {
                     assert.equal('floyd', req.get('pink'));
+                    assert.deepEqual(expectedData, req._getAllContext());
                     asserted = true;
                     res.send(200);
                     return next();

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -140,7 +140,7 @@ describe('all other plugins', function () {
             var asserted = false;
             var expectedData = {
                 pink: 'floyd'
-            }
+            };
             SERVER.get('/context', [
                 function (req, res, next) {
                     req.set('pink', 'floyd');

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -132,4 +132,31 @@ describe('all other plugins', function () {
         });
 
     });
+
+    describe('context', function () {
+        it('set and get request context', function (done) {
+            SERVER.pre(plugins.pre.context());
+
+            var asserted = false;
+            SERVER.get('/context', [
+                function (req, res, next) {
+                    req.set('pink', 'floyd');
+                    return next();
+                },
+                function (req, res, next) {
+                    assert.equal('floyd', req.get('pink'));
+                    asserted = true;
+                    res.send(200);
+                    return next();
+                }
+            ]);
+
+            CLIENT.get('/context', function (err, _, res) {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                assert.ok(asserted);
+                done();
+            });
+        });
+    });
 });

--- a/test/strictQueryParams.test.js
+++ b/test/strictQueryParams.test.js
@@ -161,7 +161,8 @@ describe('strictQueryParams', function () {
             });
     });
 
-    it('should respond to non-strict key/val query param value with 400', function (done) {
+    it('should respond to non-strict key/val query param value with 400',
+        function (done) {
 
 
         SERVER.pre(plugins.pre.strictQueryParams({


### PR DESCRIPTION
This plugin lets you use `set` and `get` methods on the `req` object instead of directly attaching state to `req`. 