### PR TITLE
Fixes both #100 and #101

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ event, e.g., `server.on('after', plugins.auditLogger());`:
   * `metrics.method` {String} http request verb
   * `metrics.latency` {Number} request latency
   * `metrics.path` {String} req.path() value
+  * `metrics.inflightRequests` {Number} Number of inflight requests pending in restify.
+  * `metrics.unifinishedRequests` {Number} Same as `inflightRequests`
   * `metrics.connectionState` {String} can be either 'close', 'aborted', or
     undefined. If this value is set, err will be a corresponding
     `RequestCloseError` or `RequestAbortedError`. If connectionState is either

--- a/lib/plugins/bodyParser.js
+++ b/lib/plugins/bodyParser.js
@@ -39,6 +39,13 @@ function bodyParser(options) {
     var parseFieldedText = fieldedTextParser(opts);
 
     function parseBody(req, res, next) {
+        // #100 don't parse the body again if we've read it once
+        if (req._parsedBody) {
+            next();
+            return;
+        } else {
+            req._parsedBody = true;
+        }
         // Allow use of 'requestBodyOnGet' flag to allow for merging of
         // the request body of a GET request into req.params
         if (req.method === 'HEAD') {

--- a/lib/plugins/bodyReader.js
+++ b/lib/plugins/bodyReader.js
@@ -67,6 +67,14 @@ function bodyReader(options) {
     var maxBodySize = opts.maxBodySize || 0;
 
     function readBody(req, res, next) {
+        // #100 don't read the body again if we've read it once
+        if (req._readBody) {
+            next();
+            return;
+        } else {
+            req._readBody = true;
+        }
+
         if ((req.getContentLength() === 0 && !req.isChunked()) ||
             req.contentType() === 'multipart/form-data' ||
             req.contentType() === 'application/octet-stream') {

--- a/lib/plugins/metrics.js
+++ b/lib/plugins/metrics.js
@@ -52,8 +52,10 @@ function createMetrics(opts, callback) {
             // metrics.
             connectionState: (req.connectionState &&
                              req.connectionState()),
-            unfinishedRequests: (opts.server.unfinishedRequests &&
-                                opts.server.unfinishedRequests())
+            unfinishedRequests: (opts.server.inflightRequests &&
+                                opts.server.inflightRequests()),
+            inflightRequests: (opts.server.inflightRequests &&
+                                opts.server.inflightRequests())
         };
 
         return callback(err, data, req, res, route);

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "istanbul": "^0.4.1",
     "jscs": "^3.0.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.5.3",
+    "mocha": "^3.2.0",
     "nsp": "^2.4.0",
     "restify": "git+https://git@github.com/restify/node-restify.git#5.x",
     "restify-clients": "^1.1.1",

--- a/test/fieldedTextParser.test.js
+++ b/test/fieldedTextParser.test.js
@@ -94,8 +94,7 @@ describe('fielded text parser', function () {
     });
 
     it('should parse CSV body even if bodyparser declared twice',
-        function (done)
-    {
+        function (done) {
         SERVER.use(plugins.bodyParser());
         var options = {
             path: '/data',

--- a/test/fieldedTextParser.test.js
+++ b/test/fieldedTextParser.test.js
@@ -55,8 +55,48 @@ describe('fielded text parser', function () {
         SERVER.close(done);
     });
 
-
     it('should parse CSV body', function (done) {
+        var options = {
+            path: '/data',
+            headers: {
+                'Content-Type': 'text/csv'
+            }
+        };
+
+        SERVER.post('/data', function respond(req, res, next) {
+            res.send({
+                status: 'okay',
+                parsedReq: req.body
+            });
+            return next();
+        });
+
+        CLIENT.post(options, function (err, req) {
+            assert.ifError(err);
+            req.on('result', function (errReq, res) {
+                assert.ifError(errReq);
+                res.body = '';
+                res.setEncoding('utf8');
+                res.on('data', function (chunk) {
+                    res.body += chunk;
+                });
+                res.on('end', function () {
+                    res.body = JSON.parse(res.body);
+                    var parsedReqStr = JSON.stringify(res.body.parsedReq);
+                    var objectStr = JSON.stringify(OBJECT_CSV);
+                    assert.equal(parsedReqStr, objectStr);
+                    done();
+                });
+            });
+            req.write(DATA_CSV);
+            req.end();
+        });
+    });
+
+    it('should parse CSV body even if bodyparser declared twice',
+        function (done)
+    {
+        SERVER.use(plugins.bodyParser());
         var options = {
             path: '/data',
             headers: {
@@ -161,6 +201,5 @@ describe('fielded text parser', function () {
             req.end();
         });
     });
-
 });
 

--- a/test/fieldedTextParser.test.js
+++ b/test/fieldedTextParser.test.js
@@ -93,7 +93,7 @@ describe('fielded text parser', function () {
         });
     });
 
-    it('should parse CSV body even if bodyparser declared twice',
+    it('#100 should parse CSV body even if bodyparser declared twice',
         function (done) {
         SERVER.use(plugins.bodyParser());
         var options = {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -98,6 +98,7 @@ describe('request metrics plugin', function () {
             assert.equal(metrics.method, 'GET');
             assert.equal(metrics.connectionState, 'close');
             assert.isNumber(metrics.unfinishedRequests);
+            assert.isNumber(metrics.inflightRequests);
             return done();
         }));
 

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -44,7 +44,7 @@ describe('request metrics plugin', function () {
     });
 
 
-    it('should return metrics for a given request', function (done) {
+    it.only('should return metrics for a given request', function (done) {
 
         SERVER.on('after', plugins.metrics({
             server: SERVER

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -44,7 +44,7 @@ describe('request metrics plugin', function () {
     });
 
 
-    it.only('should return metrics for a given request', function (done) {
+    it('should return metrics for a given request', function (done) {
 
         SERVER.on('after', plugins.metrics({
             server: SERVER


### PR DESCRIPTION
Fixes both #100 and #101 
#100 Adding bodyParser plugin twice no longer blackholes requests.
#101 Fix failing test by adding `metrics.inflightRequests` as a proxy to `unfinishedRequests`